### PR TITLE
feat: added max file rows for csv

### DIFF
--- a/frontend/src/components/attachment-handler/attachment-handler.tsx
+++ b/frontend/src/components/attachment-handler/attachment-handler.tsx
@@ -1,5 +1,6 @@
 import { FileListItemComponent } from '@components/file-list-item/file-list-item.component';
 import FileUpload from '@components/file-upload/file-upload.component';
+import { MAX_ATTACHMENT_FILE_SIZE_MB } from '@services/message-service';
 import { Divider, FormControl } from '@sk-web-gui/react';
 import { useFormContext } from 'react-hook-form';
 
@@ -47,6 +48,7 @@ const AttachmentHandler: React.FC = () => {
             allowMax={maxMain + maxSecondary}
             accept={['.pdf', '.PDF']}
             helperText="Maximal filstorlek: 2 MB. Tillåtna filtyper: pdf"
+            maxFileSizeMB={MAX_ATTACHMENT_FILE_SIZE_MB}
           />
         </FormControl>
 

--- a/frontend/src/components/file-upload/file-upload.component.tsx
+++ b/frontend/src/components/file-upload/file-upload.component.tsx
@@ -14,6 +14,8 @@ const FileUpload: React.FC<{
   helperText?: string;
   showLabel?: boolean;
   allowReplace?: boolean;
+  maxFileSizeMB?: number;
+  onErrorReset?: () => void;
 }> = (props) => {
   const {
     fieldName,
@@ -24,6 +26,8 @@ const FileUpload: React.FC<{
     helperText,
     showLabel,
     allowReplace = false,
+    maxFileSizeMB = MAX_ATTACHMENT_FILE_SIZE_MB,
+    onErrorReset,
   } = props;
   const [error, setError] = useState<string>();
   const [fileErrors, setFileErrors] = useState<string[]>([]);
@@ -66,6 +70,7 @@ const FileUpload: React.FC<{
   const fileHandler = () => {
     setFileErrors([]);
     setError(undefined);
+    onErrorReset && onErrorReset();
     // e.preventDefault();
     let N = added;
     for (let i = 0; i < newItem.length; i += 1) {
@@ -81,7 +86,7 @@ const FileUpload: React.FC<{
             const t = `Fel filtyp - ${file.name}`;
             // setError(t);
             setFileErrors((fileErrors) => [...fileErrors, t]);
-          } else if (file.size / 1024 / 1024 > MAX_ATTACHMENT_FILE_SIZE_MB) {
+          } else if (file.size / 1024 / 1024 > maxFileSizeMB) {
             const s = `Filen är för stor (${(file.size / 1024 / 1024).toFixed(1)} MB) - ${file.name}`;
             // setError(s);
             setFileErrors((fileErrors) => [...fileErrors, s]);

--- a/frontend/src/services/recipient-service.ts
+++ b/frontend/src/services/recipient-service.ts
@@ -4,7 +4,8 @@ import { __DEV__ } from '@sk-web-gui/react';
 import { devtools } from 'zustand/middleware';
 import { LetterResponse } from './message-service';
 
-const MAX_RECIPIENT_FILE_SIZE_MB = 50;
+export const MAX_RECIPIENT_FILE_SIZE_MB = 50;
+export const MAX_RECIPIENT_ROW_SIZE = 250;
 
 export interface Recipient {
   personnumber: string;
@@ -28,7 +29,7 @@ export interface Citizenaddress {
       postalCode: string;
       city: string;
       country: string;
-    }
+    },
   ];
   errorMessage?: string;
 }
@@ -91,12 +92,19 @@ export const getRecipients = async (files: { file?: File }[]): Promise<Recipient
     const formData = new FormData();
     formData.append(`files`, blob, fileItem.name);
 
+    const checkRecipientsRows = (recipients: RecipientWithAddress[]) => {
+      if (recipients.length > MAX_RECIPIENT_ROW_SIZE) {
+        throw new Error('MAX_RECIPIENT_ROW_SIZE');
+      }
+      return recipients;
+    };
+
     const postFile = () =>
       apiService
         .post<{ data: RecipientWithAddress[] }, FormData>(`recipients`, formData, {
           headers: { 'Content-Type': 'multipart/form-data' },
         })
-        .then((r) => r.data.data)
+        .then((r) => checkRecipientsRows(r.data.data))
         .catch((e) => {
           console.error('Something went wrong when posting recipient list.');
           throw e;


### PR DESCRIPTION
fix: FileUpload to use maxFileSizeMB prop

Notes:
- MAX_SIZE in recipient-handler.tsx is never triggered since size is hard-checked in FileUpload at the moment

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
