### PR TITLE
fix: use api versions from config

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -155,11 +155,11 @@ const samlStrategy = new Strategy(
         },
       };
 
-      const employeeDetails = await apiService.get<any>(
-        { url: `employee/2.0/${MUNICIPALITY_ID}/portalpersondata/PERSONAL/${employee}` },
-        dummyUser,
-      );
-      const { personid, orgTree } = employeeDetails.data;
+        const employeeDetails = await apiService.get<any>(
+          { url: `${getApiBase('employee')}/${MUNICIPALITY_ID}/portalpersondata/PERSONAL/${employee}` },
+          dummyUser,
+        );
+        const { personid, orgTree } = employeeDetails.data;
 
       // Get permissions of the user
       const permissionsUser: User = { ...dummyUser };

--- a/backend/src/controllers/health.controller.ts
+++ b/backend/src/controllers/health.controller.ts
@@ -1,3 +1,4 @@
+import { getApiBase } from '@/config';
 import { User } from '@/interfaces/users.interface';
 import ApiService from '@/services/api.service';
 import { logger } from '@/utils/logger';
@@ -11,7 +12,7 @@ export class HealthController {
   @Get('/health/up')
   @OpenAPI({ summary: 'Return health check' })
   async up() {
-    const url = `simulatorserver/2.0/simulations/response?status=200%20OK`;
+    const url = `${getApiBase('simulatorserver')}/simulations/response?status=200%20OK`;
     const data = {
       status: 'OK',
     };

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -5,7 +5,7 @@ import ApiService from '@/services/api.service';
 import authMiddleware from '@middlewares/auth.middleware';
 import { Controller, Get, Header, QueryParam, Req, Res, UseBefore } from 'routing-controllers';
 import { OpenAPI } from 'routing-controllers-openapi';
-import { MUNICIPALITY_ID } from '@/config';
+import { getApiBase, MUNICIPALITY_ID } from '@/config';
 
 interface UserData {
   name: string;
@@ -57,7 +57,7 @@ export class UserController {
       throw new HttpException(400, 'Bad Request');
     }
 
-    const url = `employee/2.0/${MUNICIPALITY_ID}/${personId}/personimage`;
+    const url = `${getApiBase('employee')}/${MUNICIPALITY_ID}/${personId}/personimage`;
     const res = await this.apiService.get<any>(
       {
         url,

--- a/backend/src/services/authorization.service.ts
+++ b/backend/src/services/authorization.service.ts
@@ -1,10 +1,7 @@
-import { AUTHORIZED_GROUPS } from '@config';
+import { AUTHORIZED_GROUPS, getApiBase, MUNICIPALITY_ID } from '@config';
 import { Permissions, User } from '@interfaces/users.interface';
 import ApiService, { ApiResponse } from './api.service';
 import { logError } from './message.service';
-
-const MESSAGING_SETTINGS_PATH = `messaging-settings/2.0`;
-const MUNICIPALITY_ID = '2281';
 
 export function authorizeGroups(groups) {
   console.log('authorizing groups', groups);
@@ -44,7 +41,7 @@ export const getMessagingUserSettings: (user: User, api: ApiService) => Promise<
   user,
   api,
 ) => {
-  const url = `${MESSAGING_SETTINGS_PATH}/${MUNICIPALITY_ID}/user`;
+  const url = `${getApiBase('messaging-settings')}/${MUNICIPALITY_ID}/user`;
   const headers = {
     'X-Sent-By': `type=adAccount; ${user.username.toLowerCase()}`,
   };


### PR DESCRIPTION
# Pull Request

## Description

use api versions from config

## Background & Motivation

Behöver använda senaste versionen av apierna för produktionssättning.
Vissa tjänster hedrar inte config och har hårdkodade api-urler.

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
