### PR TITLE
fix: makes node_modules directories readable and executable

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@ FROM registry.access.redhat.com/ubi9/nodejs-20 AS deps
 WORKDIR /app
 COPY --chown=1001:0 package.json yarn.lock ./
 
-# Read-only manifests (Sonar-safe)
+# Read-only manifests
 RUN chmod 0444 package.json yarn.lock
 
 RUN npm install -g yarn \
@@ -21,9 +21,10 @@ WORKDIR /app
 
 COPY --from=deps --chown=1001:0 /app/node_modules ./node_modules
 
-# node_modules: readable but traversable
+# node_modules: readable but traversable, make .bin executable
 RUN find ./node_modules -type d -exec chmod 0555 {} + \
- && find ./node_modules -type f -exec chmod 0444 {} +
+ && find ./node_modules -type f -exec chmod 0444 {} + \
+ && find ./node_modules/.bin -type f -exec chmod 0555 {} +
 
 COPY --chown=1001:0 . .
 


### PR DESCRIPTION
# Pull Request

## Description

node_modules och .bin ska ha korrekta permissions så att yarn build fungerar i OpenShift, samtidigt som statiska filer hålls read-only för sq

## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-1122

## General Checklist

- [x] PR follows code style and standards
- [ ] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [ ] API changes are documented (OpenAPI/README)
- [ ] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [ ] All affected pages render correctly (SSR/CSR)
- [ ] Navigation works
- [ ] API calls from the frontend continue to work
- [ ] Any forms/flows function correctly
- [ ] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [ ] Affected endpoints behave as expected
- [ ] No changes break existing contracts
- [ ] Error handling works correctly
- [ ] Logging behaves normally
- [ ] Protected endpoints validated (auth/session/JWT)
