### PR TITLE
fix: remove chmod 444 in node_modules

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@ FROM registry.access.redhat.com/ubi9/nodejs-20 AS deps
 WORKDIR /app
 COPY --chown=1001:0 package.json yarn.lock ./
 
-# Read-only manifests
+# Read-only manifests (Sonar-safe)
 RUN chmod 0444 package.json yarn.lock
 
 RUN npm install -g yarn \
@@ -18,20 +18,9 @@ RUN npm install -g yarn \
 FROM registry.access.redhat.com/ubi9/nodejs-20 AS builder
 
 WORKDIR /app
-
 COPY --from=deps --chown=1001:0 /app/node_modules ./node_modules
-
-# node_modules: readable but traversable, make .bin executable
-RUN find ./node_modules -type d -exec chmod 0555 {} + \
- && find ./node_modules -type f -exec chmod 0444 {} + \
- && find ./node_modules/.bin -type f -exec chmod 0555 {} +
-
 COPY --chown=1001:0 . .
-
-# Only lock down known static files
 RUN chmod 0444 package.json yarn.lock next.config.js || true
-
-# Build-time env placeholders
 COPY --chown=1001:0 .env-cicd .env.local
 RUN chmod 0444 .env-cicd .env.local
 
@@ -62,11 +51,11 @@ COPY --from=builder /app/package.json ./
 COPY --from=builder --chown=1001:0 /app/.next/standalone ./
 COPY --from=builder --chown=1001:0 /app/.next/static ./.next/static
 
-# Allow runtime env replacement
+# Make .next directory group-writable for OpenShift
 RUN chmod -R g+w /app/.next
 
 # Entrypoint
-COPY --chown=1001:0 entrypoint.sh ./entrypoint.sh
+COPY --chown=1001:0 entrypoint.sh ./
 RUN chmod 0555 entrypoint.sh \
  && sed -i 's/\r$//' ./entrypoint.sh
 


### PR DESCRIPTION
# Pull Request

## Description

Justera Dockerfile så att node_modules behåller exekverbara permissions på .bin-filer, så att yarn build kan köras i builder-steget. Statisk read-only behålls på package.json, yarn.lock, next.config.js och .env* för att uppfylla Sonar-säkerhetskrav.

## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-1124

## General Checklist

- [x] PR follows code style and standards
- [ ] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [ ] ESLint/Prettier have been run and are OK
- [ ] API changes are documented (OpenAPI/README)
- [ ] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [ ] All affected pages render correctly (SSR/CSR)
- [ ] Navigation works
- [ ] API calls from the frontend continue to work
- [ ] Any forms/flows function correctly
- [ ] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [ ] Affected endpoints behave as expected
- [ ] No changes break existing contracts
- [ ] Error handling works correctly
- [ ] Logging behaves normally
- [ ] Protected endpoints validated (auth/session/JWT)
