### PR TITLE
fix: remove from a help answer the separation of csv file content.

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-app-dispatch-portal--backen",
-  "version": "1.0.0",
+  "version": "2.1.1",
   "description": "Backend for Dispatch portal",
   "author": "",
   "license": "ISC",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sk-web-gui/web-app-dispatch-portal",
-  "version": "0.1.0",
+  "version": "2.1.1",
   "private": true,
   "packageManager": "yarn@1.22.22",
   "scripts": {

--- a/frontend/public/locales/sv/help-menu.json
+++ b/frontend/public/locales/sv/help-menu.json
@@ -74,7 +74,7 @@
     },
     "18": {
       "question": "Hur skapar jag en mottagarlista?",
-      "answer": "<p>Öppna ett nytt exceldokument och skriv in personnumren i den första kolumnen. Fyll i med tolv siffror, med eller utan bindestreck. Välj sedan att exportera excelfilen till formatet .csv och ange semikolon som separator. När du sparat filen kan du dra den till det markerade området, eller välja att bläddra fram den.</p><p>Kontrollera gärna din mottagarlista i t ex Notepad/Anteckningar efter du skapat den, för att se att den ser ut som den ska, eftersom Excel ibland formaterar om exempelvis personnummer.</p><p>Använd gärna <a>exempelfilen</a> när du skapar din mottagarlista.</p>"
+      "answer": "<p>Öppna ett nytt exceldokument och skriv in personnumren i den första kolumnen. Fyll i med tolv siffror, med eller utan bindestreck. Välj sedan att exportera excelfilen till formatet .csv. När du sparat filen kan du dra den till det markerade området, eller välja att bläddra fram den.</p><p>Kontrollera gärna din mottagarlista i t ex Notepad/Anteckningar efter du skapat den, för att se att den ser ut som den ska, eftersom Excel ibland formaterar om exempelvis personnummer.</p><p>Använd gärna <a>exempelfilen</a> när du skapar din mottagarlista.</p>"
     },
     "19": {
       "question": "Vad ska jag skriva i fältet för ämne?",


### PR DESCRIPTION
# Pull Request

## Description

Modified one question answer by just removing the part talking about the column separator in csv file.

## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-1116

## Fix version
PP-2.1.0

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
