### PR TITLE
Feat/hydran 1824 update modal

### DIFF
--- a/frontend/cypress/e2e/send-mail.cy.ts
+++ b/frontend/cypress/e2e/send-mail.cy.ts
@@ -85,17 +85,15 @@ pages.forEach((p) => {
           cy.get('.sk-form-error-message').contains('Kunde inte hitta några giltiga mottagare.');
         });
 
-        it('should show dialog when adding a csv file with duplicate recipients', () => {
-          cy.intercept('POST', '**/api/recipient/csv', recipientcsv('OK', { duplicates: true, rejections: true })).as(
+        it('should show dialog when adding a csv file with rejected recipients', () => {
+          cy.intercept('POST', '**/api/recipient/csv', recipientcsv('OK', { rejections: true })).as(
             'csv'
           );
           addCsv();
           cy.get('.sk-modal-dialog.sk-dialog')
             .eq(0)
             .within(() => {
-              cy.get('h1').should('include.text', 'Filen innehåller problem');
-              cy.get('p').contains('Filen innehåller 2 personnummer med dubbletter.');
-              cy.get('p').contains('Filen innehåller 2 felaktiga personnummer.');
+              cy.get('h1').should('include.text', 'Filen personal-numbers.csv innehåller 2 ogiltiga personnummer.');
               cy.get('button').contains('Fortsätt ändå').click();
             });
           cy.get('[data-cy="recipientlist"]').contains('personal-numbers.csv').should('be.visible');

--- a/frontend/public/locales/sv/send-mail.json
+++ b/frontend/public/locales/sv/send-mail.json
@@ -70,7 +70,7 @@
     "csvWarning": {
       "title_one": "Filen {csvFile} innehåller {count} ogiltigt personnummer.",
       "title_other": "Filen {csvFile} innehåller {count} ogiltiga personnummer.",
-      "description": "Personnumren kommer tas bort från utskicket. Vill du fortsätta utan dessa?",
+      "description": "Vill du fortsätta utan dessa mottagare?",
       "confirm": "Fortsätt ändå",
       "cancel": "Avbryt"
     },

--- a/frontend/public/locales/sv/send-mail.json
+++ b/frontend/public/locales/sv/send-mail.json
@@ -68,7 +68,8 @@
     "csvHelperText": "Tillåtna filtyper: csv. Maximalt antal rader: 250",
     "csvAddedFile": "Tillagd fil",
     "csvWarning": {
-      "title": "Filen {csvFile} innehåller {count} ogiltiga personnummer.",
+      "title_one": "Filen {csvFile} innehåller {count} ogiltigt personnummer.",
+      "title_other": "Filen {csvFile} innehåller {count} ogiltiga personnummer.",
       "description": "Personnumren kommer tas bort från utskicket. Vill du fortsätta utan dessa?",
       "confirm": "Fortsätt ändå",
       "cancel": "Avbryt"

--- a/frontend/public/locales/sv/send-mail.json
+++ b/frontend/public/locales/sv/send-mail.json
@@ -68,12 +68,8 @@
     "csvHelperText": "Tillåtna filtyper: csv. Maximalt antal rader: 250",
     "csvAddedFile": "Tillagd fil",
     "csvWarning": {
-      "title": "Filen innehåller problem.",
-      "duplicates_one": "Filen innehåller {count} personnummer med dubbletter.",
-      "duplicates_other": "Filen innehåller {count} personnummer med dubbletter.",
-      "rejections_one": "Filen innehåller {count} felaktigt personnummer.",
-      "rejections_other": "Filen innehåller {count} felaktiga personnummer.",
-      "description": "Du kan välja att fortsätta ändå. Utskicket kommer endast skickas en gång per mottagare.",
+      "title": "Filen {csvFile} innehåller {count} ogiltiga personnummer.",
+      "description": "Personnumren kommer tas bort från utskicket. Vill du fortsätta utan dessa?",
       "confirm": "Fortsätt ändå",
       "cancel": "Avbryt"
     },

--- a/frontend/public/locales/sv/send-sms.json
+++ b/frontend/public/locales/sv/send-sms.json
@@ -23,7 +23,8 @@
     }
   },
   "csvWarning": {
-    "title": "Filen {csvFile} innehåller {count} ogiltiga mobilnummer.",
+    "title_one": "Filen {csvFile} innehåller {count} ogiltigt mobilnummer.",
+    "title_other": "Filen {csvFile} innehåller {count} ogiltiga mobilnummer.",
     "description": "Mobilnumren kommer tas bort från utskicket. Vill du fortsätta utan dessa?",
     "confirm": "Fortsätt ändå",
     "cancel": "Avbryt"

--- a/frontend/public/locales/sv/send-sms.json
+++ b/frontend/public/locales/sv/send-sms.json
@@ -25,7 +25,7 @@
   "csvWarning": {
     "title_one": "Filen {csvFile} innehåller {count} ogiltigt mobilnummer.",
     "title_other": "Filen {csvFile} innehåller {count} ogiltiga mobilnummer.",
-    "description": "Mobilnumren kommer tas bort från utskicket. Vill du fortsätta utan dessa?",
+    "description": "Vill du fortsätta utan dessa mottagare?",
     "confirm": "Fortsätt ändå",
     "cancel": "Avbryt"
   },

--- a/frontend/public/locales/sv/send-sms.json
+++ b/frontend/public/locales/sv/send-sms.json
@@ -23,12 +23,8 @@
     }
   },
   "csvWarning": {
-    "title": "Filen innehåller problem.",
-    "duplicates_one": "Filen innehåller {count} telefonnummer med dubbletter.",
-    "duplicates_other": "Filen innehåller {count} telefonnummer med dubbletter.",
-    "rejections_one": "Filen innehåller {count} felaktigt telefonnummer.",
-    "rejections_other": "Filen innehåller {count} felaktiga telefonnummer.",
-    "description": "Du kan välja att fortsätta ändå. Utskicket kommer endast skickas en gång per mottagare.",
+    "title": "Filen {csvFile} innehåller {count} ogiltiga mobilnummer.",
+    "description": "Mobilnumren kommer tas bort från utskicket. Vill du fortsätta utan dessa?",
     "confirm": "Fortsätt ändå",
     "cancel": "Avbryt"
   },

--- a/frontend/src/components/recipient-handler/components/csv-file-sms.component.tsx
+++ b/frontend/src/components/recipient-handler/components/csv-file-sms.component.tsx
@@ -8,7 +8,6 @@ export const CsvSmsRecipients: React.FC = () => {
     checkCsv: checkCsvSms,
     warningKeys: {
       title: 'send-sms:csvWarning.title',
-      duplicates: 'send-sms:csvWarning.duplicates',
       rejections: 'send-sms:csvWarning.rejections',
       description: 'send-sms:csvWarning.description',
       confirm: 'send-sms:csvWarning.confirm',

--- a/frontend/src/components/recipient-handler/components/csv-file.component.tsx
+++ b/frontend/src/components/recipient-handler/components/csv-file.component.tsx
@@ -8,7 +8,6 @@ export const CsvRecipients: React.FC = () => {
     checkCsv,
     warningKeys: {
       title: 'send-mail:recipientHandler.csvWarning.title',
-      duplicates: 'send-mail:recipientHandler.csvWarning.duplicates',
       rejections: 'send-mail:recipientHandler.csvWarning.rejections',
       description: 'send-mail:recipientHandler.csvWarning.description',
       confirm: 'send-mail:recipientHandler.csvWarning.confirm',

--- a/frontend/src/components/recipient-handler/hooks/use-csv-file-handler.tsx
+++ b/frontend/src/components/recipient-handler/hooks/use-csv-file-handler.tsx
@@ -1,5 +1,6 @@
 import { Attachment } from '@components/attachment-handler/attachment-handler';
 import { CustomOnChangeEventUploadFile, useConfirm } from '@sk-web-gui/react';
+import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Csv } from 'src/data-contracts/backend/data-contracts';
@@ -10,7 +11,6 @@ interface CsvRecipientFileFormModel {
 
 interface CsvWarningKeys {
   title: string;
-  duplicates: string;
   rejections: string;
   description: string;
   confirm: string;
@@ -39,20 +39,36 @@ export const useCsvRecipientFileHandler = ({ checkCsv, warningKeys, errorKeys }:
     formState: { errors },
   } = useFormContext<CsvRecipientFileFormModel>();
 
-  const handleWarningMessage = (csvData: Csv) => {
-    const countDuplicates = Object.keys(csvData.duplicateEntries ?? {}).length;
-    const countRejections = (csvData.rejectedEntries ?? []).length;
-    const hasWarnings = countDuplicates > 0 || countRejections > 0;
 
-    if (!hasWarnings) return null;
+  const handleWarningMessage = (
+    csvData: Csv
+  ): {
+    countRejections: number;
+    warningMessage: ReactElement | null;
+  } => {
+    const rejectedEntries = (csvData.rejectedEntries ?? []).filter(Boolean);
+    const countRejections = rejectedEntries.length;
 
-    return (
-      <>
-        {countDuplicates > 0 && <p>{t(warningKeys.duplicates, { count: countDuplicates })}</p>}
-        {countRejections > 0 && <p>{t(warningKeys.rejections, { count: countRejections })}</p>}
-        <p>{t(warningKeys.description)}</p>
-      </>
-    );
+    if (countRejections === 0) {
+      return { countRejections: 0, warningMessage: null };
+    }
+
+    return {
+      countRejections,
+      warningMessage: (
+        <>
+          <p>{t(warningKeys.description)}</p>
+
+          {countRejections > 0 && (
+            <div>
+              {rejectedEntries.map((entry) => (
+                <p key={entry}>{entry}</p>
+              ))}
+            </div>
+          )}
+        </>
+      ),
+    };
   };
 
   const handleFiles = async (event: CustomOnChangeEventUploadFile) => {
@@ -77,18 +93,18 @@ export const useCsvRecipientFileHandler = ({ checkCsv, warningKeys, errorKeys }:
 
     clearErrors('recipientList');
 
-    const warningMessage = handleWarningMessage(csvData);
+    const { warningMessage, countRejections } = handleWarningMessage(csvData);
+
     if (!warningMessage) {
       setValue('recipientList', [{ ...csvData, file }]);
       return;
     }
 
     const confirmed = await showConfirmation(
-      t(warningKeys.title),
+      t(warningKeys.title, { csvFile: csvData.name, count: countRejections }),
       warningMessage,
       t(warningKeys.confirm),
-      t(warningKeys.cancel),
-      'warning'
+      t(warningKeys.cancel)
     );
     setValue('recipientList', confirmed ? [{ ...csvData, file }] : []);
   };


### PR DESCRIPTION
# Pull Request

## Description

Updates display of warning messages in modal for csv uploads (mail and sms).
Removes messages for duplicate entries, now only displays rejected entries.

## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-1824

## General Checklist

- [X] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [X] Project builds locally without errors
- [X] ESLint/Prettier have been run and are OK
- [X] API changes are documented (OpenAPI/README)
- [X] Environment variables updated if necessary

## Manual Regression Testing

### Frontend – Next.js

- [X] All affected pages render correctly (SSR/CSR)
- [X] Navigation works
- [X] API calls from the frontend continue to work
- [X] Any forms/flows function correctly
- [X] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [X] Affected endpoints behave as expected
- [X] No changes break existing contracts
- [X] Error handling works correctly
- [X] Logging behaves normally
- [X] Protected endpoints validated (auth/session/JWT)
