### PR TITLE
Feat/hydran 2340 update message details

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Dessa APIer används i projektet, applikationsanvändaren i WSO2 måste prenumer
 | Company           |     1.0 |
 | Employee          |     2.0 |
 | Citizen           |     3.0 |
-| PostPortalService |     1.6 |
+| PostPortalService |     1.7 |
 | MessagingSettings |     3.0 |
 | LegalEntity       |     2.0 |
 

--- a/backend/src/config/api-config.ts
+++ b/backend/src/config/api-config.ts
@@ -22,7 +22,7 @@ export const APIS = [
   },
   {
     name: 'postportalservice',
-    version: '1.6',
+    version: '1.7',
   },
   { name: 'legalentity', 
     version: '2.0' 

--- a/backend/src/services/message.service.ts
+++ b/backend/src/services/message.service.ts
@@ -198,12 +198,31 @@ export const sendLetter: (
   const municipalityId = await getMunicipalityId(req);
   const url = `${POSTPORTALSERVICE_PATH}/${municipalityId}/messages/letter`;
 
-  // Adress is only required for SNAIL_MAIL
-  const sanitizedRecipients: Recipient[] = recipients.map(recipient =>
-    recipient.deliveryMethod === RecipientDeliveryMethodEnum.SNAIL_MAIL || recipient.address?.street
-      ? recipient
-      : { ...recipient, address: undefined },
-  );
+  const carriesName = (address?: Address) => !!(address?.organizationName || address?.firstName || address?.lastName);
+
+  const PLACEHOLDER = '-';
+
+  const padForDigital = (address: Address): Address => ({
+    ...address,
+    street: address.street || PLACEHOLDER,
+    zipCode: address.zipCode || PLACEHOLDER,
+    city: address.city || PLACEHOLDER,
+    country: address.country || PLACEHOLDER,
+  });
+
+  const sanitizedRecipients: Recipient[] = recipients.map(recipient => {
+    // address is required for snail mail
+    if (recipient.deliveryMethod === RecipientDeliveryMethodEnum.SNAIL_MAIL) {
+      return recipient;
+    }
+
+    // otherwise pad address with what is necessary so name gets passed
+    if (recipient.address && carriesName(recipient.address)) {
+      return { ...recipient, address: padForDigital(recipient.address) };
+    }
+
+    return { ...recipient, address: undefined };
+  });
 
   const request: LetterRequest = {
     subject: subject,

--- a/backend/src/services/message.service.ts
+++ b/backend/src/services/message.service.ts
@@ -198,7 +198,8 @@ export const sendLetter: (
   const municipalityId = await getMunicipalityId(req);
   const url = `${POSTPORTALSERVICE_PATH}/${municipalityId}/messages/letter`;
 
-  const carriesName = (address?: Address) => !!(address?.organizationName || address?.firstName || address?.lastName);
+  const carriesName = (address?: Address): address is Address =>
+    !!(address?.organizationName || address?.firstName || address?.lastName);
 
   const PLACEHOLDER = '-';
 
@@ -211,13 +212,13 @@ export const sendLetter: (
   });
 
   const sanitizedRecipients: Recipient[] = recipients.map(recipient => {
-    // address is required for snail mail
-    if (recipient.deliveryMethod === RecipientDeliveryMethodEnum.SNAIL_MAIL) {
+    const addressRequiredForSnailMail = recipient.deliveryMethod === RecipientDeliveryMethodEnum.SNAIL_MAIL;
+
+    if (addressRequiredForSnailMail) {
       return recipient;
     }
 
-    // otherwise pad address with what is necessary so name gets passed
-    if (recipient.address && carriesName(recipient.address)) {
+    if (carriesName(recipient.address)) {
       return { ...recipient, address: padForDigital(recipient.address) };
     }
 


### PR DESCRIPTION
# Pull Request

## Description

- Uppdaterar postportalservice från 1.6 till 1.7.
- Lägger till helper för att spara namn på en mottagare (DIGITAL_MAIL) ifall fullständig adress saknas, adress + namn sparas i samma objekt - så när adress saknas så sparas heller inget namn eftersom allt som krävs för digitalt utskick är partyId.

## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-1316

## General Checklist

- [X] PR follows code style and standards
- [X] E2E tests (Cypress) have been executed, and new tests have been added if required
- [X] Project builds locally without errors
- [X] ESLint/Prettier have been run and are OK
- [X] API changes are documented (OpenAPI/README)
- [X] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [X] All affected pages render correctly (SSR/CSR)
- [X] Navigation works
- [X] API calls from the frontend continue to work
- [X] Any forms/flows function correctly
- [X] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [X] Affected endpoints behave as expected
- [X] No changes break existing contracts
- [X] Error handling works correctly
- [X] Logging behaves normally
- [X] Protected endpoints validated (auth/session/JWT)