### PR TITLE
Chore/hydran 2681 fix lint errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+permissions:
+  contents: read
+
+on: [workflow_dispatch, pull_request]
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [frontend, admin]
+    name: ESLint (${{ matrix.app }})
+    defaults:
+      run:
+        working-directory: ${{ matrix.app }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+          cache-dependency-path: ${{ matrix.app }}/yarn.lock
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile --silent --network-timeout 1000000
+
+      - name: Run ESLint
+        run: yarn lint

--- a/admin/eslint.config.mjs
+++ b/admin/eslint.config.mjs
@@ -18,7 +18,19 @@ export default [
       globals: { ...globals.node, ...globals.browser, ...globals.jest },
     },
     rules: {
-      'react-refresh/only-export-components': ['error', { allowExportNames: ['getServerSideProps'] }],
+      'react-refresh/only-export-components': [
+        'error',
+        {
+          allowExportNames: [
+            'generateMetadata',
+            'generateStaticParams',
+            'metadata',
+            'dynamic',
+            'revalidate',
+            'getServerSideProps',
+          ],
+        },
+      ],
       '@typescript-eslint/no-explicit-any': 'error',
     },
   },

--- a/admin/src/app/[locale]/[resource]/[id]/layout.tsx
+++ b/admin/src/app/[locale]/[resource]/[id]/layout.tsx
@@ -17,7 +17,7 @@ export const generateMetadata = async ({ params }: Readonly<EditResourceLayoutPr
   const resource = stringToResourceName(typeof _resource === 'object' ? _resource[0] : _resource);
   const isNew = !id || id === 'new';
 
-  let title =
+  const title =
     isNew ?
       capitalize(t('common:create_new', { resource: t(`${resource}:name`, { count: 1 }) }))
     : capitalize(t('common:edit', { resource: t(`${resource}:name`, { count: 1 }) }));

--- a/admin/src/components/edit-logotypes/edit-logotype.component.tsx
+++ b/admin/src/components/edit-logotypes/edit-logotype.component.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import { FieldValues, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { EditResourceInput } from '../edit-resource/edit-resource-input.component';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 interface EditLogotypesProps {
   isNew?: boolean;
@@ -12,7 +12,6 @@ interface EditLogotypesProps {
 
 export const EditLogotype: React.FC<EditLogotypesProps> = ({ property }) => {
   const { t } = useTranslation();
-  const [localUrl, setLocalUrl] = useState<string>('');
 
   type CreateType = Parameters<NonNullable<Resource<FieldValues>['create']>>[0];
   type UpdateType = Parameters<NonNullable<Resource<FieldValues>['update']>>[1];
@@ -21,14 +20,12 @@ export const EditLogotype: React.FC<EditLogotypesProps> = ({ property }) => {
   const { watch } = useFormContext<DataType>();
   const logotype = watch(property);
 
+  const localUrl = useMemo(() => (logotype instanceof File ? URL.createObjectURL(logotype) : ''), [logotype]);
+
   useEffect(() => {
-    if (logotype instanceof File) {
-      const url = URL.createObjectURL(logotype);
-      setLocalUrl(url);
-      return () => URL.revokeObjectURL(url);
-    }
-    setLocalUrl('');
-  }, [logotype]);
+    if (!localUrl) return;
+    return () => URL.revokeObjectURL(localUrl);
+  }, [localUrl]);
 
   const fallbackSrc = typeof logotype === 'string' ? logotype : '';
   const previewSrc = logotype instanceof File ? localUrl : fallbackSrc;

--- a/admin/src/components/edit-resource/edit-resource-array.component.tsx
+++ b/admin/src/components/edit-resource/edit-resource-array.component.tsx
@@ -88,7 +88,6 @@ export const EditResourceArray: React.FC<EditResourceArrayProps> = ({
           | Merge<FieldError, FieldErrorsImpl<DataType>>
           | undefined;
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return errors?.[key];
     }, undefined);
 

--- a/admin/src/components/edit-resource/edit-resource-input.component.tsx
+++ b/admin/src/components/edit-resource/edit-resource-input.component.tsx
@@ -5,13 +5,12 @@ import { EditResourceImage } from '@components/edit-resource/edit-resource-image
 
 type InputProps = React.ComponentPropsWithoutRef<typeof Input.Component>;
 
-interface EditResourceInputProps extends Omit<InputProps, 'ref' | 'key'> {
+interface EditResourceInputProps extends Omit<InputProps, 'ref' | 'key' | 'defaultValue'> {
   label: string;
   property: string;
   index?: number;
   required?: boolean;
-  // eslint-disable-next-line no any
-  defaultValue?: any;
+  defaultValue?: unknown;
 }
 
 export const EditResourceInput: React.FC<EditResourceInputProps> = ({

--- a/admin/src/components/edit-resource/edit-resource.component.tsx
+++ b/admin/src/components/edit-resource/edit-resource.component.tsx
@@ -1,6 +1,6 @@
 import { defaultInformationFields } from '@config/defaults';
 import resources from '@config/resources';
-import { Resource } from '@interfaces/resource';
+import { Resource, ResourceData } from '@interfaces/resource';
 import { ResourceName } from '@interfaces/resource-name';
 import { Fragment } from 'react';
 import { FieldValues, useFormContext } from 'react-hook-form';
@@ -18,8 +18,7 @@ interface EditResourceProps {
 
 export const EditResource: React.FC<EditResourceProps> = ({ resource }) => {
   const { t } = useTranslation();
-  //eslint-disable-next-line implicit-any
-  const { requiredFields, hiddenFields, defaultValues } = resources[resource] as Resource<any>;
+  const { requiredFields, hiddenFields, defaultValues } = resources[resource] as Resource<ResourceData>;
 
   type CreateType = Parameters<NonNullable<Resource<FieldValues>['create']>>[0];
   type UpdateType = Parameters<NonNullable<Resource<FieldValues>['update']>>[1];

--- a/admin/src/components/menu/menu.tsx
+++ b/admin/src/components/menu/menu.tsx
@@ -20,7 +20,6 @@ export const Menu = () => {
     } else {
       setCurrent('');
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [path]);
 
   useEffect(() => {

--- a/admin/src/utils/use-crud-helpers.ts
+++ b/admin/src/utils/use-crud-helpers.ts
@@ -7,7 +7,7 @@ export const useCrudHelper = (resource: string) => {
   const message = useSnackbar();
   const { t } = useTranslation();
 
-  const handleGetOne = async <TData extends ResourceResponse<any> = ResourceResponse<unknown>>(getOne: () => TData) => {
+  const handleGetOne = async <T>(getOne: () => ResourceResponse<T>): Promise<T | undefined> => {
     const name = t(`${resource}:name_one`);
     try {
       const result = await getOne();
@@ -17,9 +17,7 @@ export const useCrudHelper = (resource: string) => {
     }
   };
 
-  const handleGetMany = async <TData extends ResourceResponse<any> = ResourceResponse<unknown>>(
-    getMany: () => TData
-  ) => {
+  const handleGetMany = async <T>(getMany: () => ResourceResponse<T>): Promise<T | undefined> => {
     const name = t(`${resource}:name_many`);
     try {
       const result = await getMany();
@@ -29,7 +27,7 @@ export const useCrudHelper = (resource: string) => {
     }
   };
 
-  const handleCreate = async <TData extends ResourceResponse<any> = ResourceResponse<unknown>>(create: () => TData) => {
+  const handleCreate = async <T>(create: () => ResourceResponse<T>): Promise<T | undefined> => {
     const name = t(`${resource}:name_one`);
     try {
       const result = await create();
@@ -42,7 +40,7 @@ export const useCrudHelper = (resource: string) => {
     }
   };
 
-  const handleUpdate = async <TData extends ResourceResponse<any> = ResourceResponse<unknown>>(update: () => TData) => {
+  const handleUpdate = async <T>(update: () => ResourceResponse<T>): Promise<T | undefined> => {
     const name = t(`${resource}:name_one`);
     try {
       const result = await update();
@@ -55,7 +53,7 @@ export const useCrudHelper = (resource: string) => {
     }
   };
 
-  const handleRemove = async <TData extends ResourceResponse<any> = ResourceResponse<unknown>>(remove: () => TData) => {
+  const handleRemove = async <T>(remove: () => ResourceResponse<T>): Promise<T | undefined> => {
     const name = t(`${resource}:name_one`);
     try {
       const result = await remove();

--- a/admin/src/utils/use-resource.ts
+++ b/admin/src/utils/use-resource.ts
@@ -1,4 +1,5 @@
 import resources from '@config/resources';
+import { ResourceData } from '@interfaces/resource';
 import { ResourceName } from '@interfaces/resource-name';
 import 'dotenv';
 import { useCallback, useEffect } from 'react';
@@ -21,7 +22,7 @@ export const useResource = (resource: ResourceName) => {
   const refresh = useCallback(() => {
     if (getMany) {
       setLoading(resource, true);
-      handleGetMany<ReturnType<typeof getMany>>(getMany)
+      handleGetMany<ResourceData[]>(getMany)
         .then((res) => {
           if (res) {
             setData(resource, res);

--- a/admin/src/views/edit-resource-view.component.tsx
+++ b/admin/src/views/edit-resource-view.component.tsx
@@ -68,7 +68,7 @@ export const EditResourceView: React.FC<EditResourceViewProps> = ({ resource: _r
           return;
         }
         const mappedRes = Object.keys(res).reduce((data, key) => {
-          return { ...data, [key]: res?.[key] ?? (defaultValues as any)?.[key] };
+          return { ...data, [key]: res?.[key] ?? (defaultValues as Record<string, unknown> | undefined)?.[key] };
         }, {});
         reset(mappedRes);
         setIsNew(false);

--- a/admin/src/views/edit-resource-view.component.tsx
+++ b/admin/src/views/edit-resource-view.component.tsx
@@ -63,6 +63,10 @@ export const EditResourceView: React.FC<EditResourceViewProps> = ({ resource: _r
   useEffect(() => {
     if (id) {
       handleGetOne(() => (getOne as NonNullable<Resource<FieldValues>['getOne']>)(id)).then((res) => {
+        if (!res) {
+          setLoaded(true);
+          return;
+        }
         const mappedRes = Object.keys(res).reduce((data, key) => {
           return { ...data, [key]: res?.[key] ?? (defaultValues as any)?.[key] };
         }, {});

--- a/frontend/src/components/add-with-address-dialog/add-with-address-dialog.component.tsx
+++ b/frontend/src/components/add-with-address-dialog/add-with-address-dialog.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { Button, Input, FormControl, FormLabel, Modal, RadioButton, cx } from '@sk-web-gui/react';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -79,12 +79,15 @@ export const AddWithAddressDialog: React.FC<AddWithAddressDialogProps> = ({
     onClose(data);
   };
 
-  useEffect(() => {
+  // Reset the dialog back to its first step whenever it is reopened.
+  const [wasOpen, setWasOpen] = useState<boolean>(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
     if (open) {
       setIsAdding(false);
       setCurrent(0);
     }
-  }, [open]);
+  }
 
   const handleClose = () => {
     reset();

--- a/frontend/src/components/help/help.component.tsx
+++ b/frontend/src/components/help/help.component.tsx
@@ -17,7 +17,7 @@ interface ISection {
 export const Help: React.FC<HelpProps> = ({ filterTag, size: _size }) => {
   const { isMinMd } = useThemeQueries();
   const qaItems = useHelpQA();
-  const { t, i18n } = useTranslation(['help-menu']);
+  const { t } = useTranslation(['help-menu']);
 
   const size = _size || (isMinMd ? 'md' : 'sm');
 
@@ -42,7 +42,7 @@ export const Help: React.FC<HelpProps> = ({ filterTag, size: _size }) => {
         },
         { header: t('help-menu:categoryHeaders.sms'), items: qaItems.filter((q) => [22, 23, 24].includes(Number(q.id))) },
       ],
-    [t, i18n.language]
+    [t]
   );
 
   const sections = useMemo(() => {

--- a/frontend/src/components/help/useHelpQA.tsx
+++ b/frontend/src/components/help/useHelpQA.tsx
@@ -1,7 +1,40 @@
 import { JSX, useMemo } from 'react';
 import { cx, Link, List } from '@sk-web-gui/react';
 import { Trans, useTranslation } from 'next-i18next';
+import type { TFunction } from 'i18next';
 import { EnumQATags, QAItem } from 'src/types';
+
+const splitInParagraphs = (text: string, id: string) =>
+  text.split('\n').map((paragraph, index) => (
+    <p
+      key={`helpparagraph-${id}-${index}`}
+      className={cx(index > 0 ? 'mt-8 leading-normal' : 'leading-normal', 'text-justify [hyphens:auto]')}
+    >
+      {paragraph}
+    </p>
+  ));
+
+const itemsFactory = (
+  t: TFunction,
+  ids: number[],
+  tags: EnumQATags[],
+  components?: { [key: string]: JSX.Element }
+) => {
+  if (components) {
+    return ids.map((i) => ({
+      id: String(i),
+      question: t(`help-menu:questionsAndAnswers.${i}.question`),
+      answer: <Trans i18nKey={`help-menu:questionsAndAnswers.${i}.answer`} components={components} />,
+      tags,
+    }));
+  }
+  return ids.map((i) => ({
+    id: String(i),
+    question: t(`help-menu:questionsAndAnswers.${i}.question`),
+    answer: splitInParagraphs(t(`help-menu:questionsAndAnswers.${i}.answer`), String(i)),
+    tags,
+  }));
+};
 
 /**
  * Hook that provides a sorted array of help Q&A items with translations and tags.
@@ -19,41 +52,14 @@ import { EnumQATags, QAItem } from 'src/types';
  * // Returns items sorted by ID: [1, 2, 3, ..., 27, 28]
  */
 export const useHelpQA = (): QAItem[] => {
-  const { t, i18n } = useTranslation(['help-menu']);
-
-  const splitInParagraphs = (text: string, id: string) =>
-    text.split('\n').map((paragraph, index) => (
-      <p
-        key={`helpparagraph-${id}-${index}`}
-        className={cx(index > 0 ? 'mt-8 leading-normal' : 'leading-normal', 'text-justify [hyphens:auto]')}
-      >
-        {paragraph}
-      </p>
-    ));
-
-  const itemsFactory = (ids: number[], tags: EnumQATags[], components?: { [key: string]: JSX.Element }) => {
-    if (components) {
-      return ids.map((i) => ({
-        id: String(i),
-        question: t(`help-menu:questionsAndAnswers.${i}.question`),
-        answer: <Trans i18nKey={`help-menu:questionsAndAnswers.${i}.answer`} components={components} />,
-        tags,
-      }));
-    }
-    return ids.map((i) => ({
-      id: String(i),
-      question: t(`help-menu:questionsAndAnswers.${i}.question`),
-      answer: splitInParagraphs(t(`help-menu:questionsAndAnswers.${i}.answer`), String(i)),
-      tags,
-    }));
-  };
+  const { t } = useTranslation(['help-menu']);
 
   const items = useMemo(
     () =>
       [
-        ...itemsFactory([1], [EnumQATags.SMS, EnumQATags.MAIL, EnumQATags.REK_MAIL]),
-        ...itemsFactory([2, 4, 5, 6, 7, 9, 12, 13, 16, 17, 18], [EnumQATags.MAIL, EnumQATags.REK_MAIL]),
-        ...itemsFactory([3, 8, 10, 14, 15], [EnumQATags.MAIL, EnumQATags.REK_MAIL], {
+        ...itemsFactory(t, [1], [EnumQATags.SMS, EnumQATags.MAIL, EnumQATags.REK_MAIL]),
+        ...itemsFactory(t, [2, 4, 5, 6, 7, 9, 12, 13, 16, 17, 18], [EnumQATags.MAIL, EnumQATags.REK_MAIL]),
+        ...itemsFactory(t, [3, 8, 10, 14, 15], [EnumQATags.MAIL, EnumQATags.REK_MAIL], {
           p: <p className="mt-4 mb-4 leading-normal text-justify [hyphens:auto]" />,
           br: <br />,
           List: <List listStyle="bullet" />,
@@ -66,18 +72,18 @@ export const useHelpQA = (): QAItem[] => {
             </a>
           ),
         }),
-        ...itemsFactory([11], [EnumQATags.MAIL], {
+        ...itemsFactory(t, [11], [EnumQATags.MAIL], {
           p: <p className="mt-4 leading-normal text-justify [hyphens:auto]" />,
           a: <Link href="/files/example-personnummer.csv" />,
         }),
-        ...itemsFactory([24], [EnumQATags.SMS], {
+        ...itemsFactory(t, [24], [EnumQATags.SMS], {
           p: <p className="mt-4 leading-normal text-justify [hyphens:auto]" />,
           a: <Link href="/files/example-mobilnummer.csv" />,
         }),
-        ...itemsFactory([19, 20, 21], [EnumQATags.REK_MAIL]),
-        ...itemsFactory([22, 23], [EnumQATags.SMS]),
+        ...itemsFactory(t, [19, 20, 21], [EnumQATags.REK_MAIL]),
+        ...itemsFactory(t, [22, 23], [EnumQATags.SMS]),
       ].sort((a, b) => Number(a.id) - Number(b.id)),
-    [i18n.language]
+    [t]
   );
 
   return items;

--- a/frontend/src/components/main-menu/main-menu.component.tsx
+++ b/frontend/src/components/main-menu/main-menu.component.tsx
@@ -1,26 +1,21 @@
 import { NavigationBar } from '@sk-web-gui/react';
 import NextLink from 'next/link';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { mainMenuItems } from './main-menu-items';
 import { usePathname } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 
+const getActiveItem = (pathname: string) => {
+  if (pathname.startsWith('/my-statistics')) return 1;
+  if (pathname === '/statistics') return 2;
+  return 0;
+};
+
 export const MainMenu: React.FC = () => {
-  const [active, setActive] = useState<number>(0);
   const pathname = usePathname();
   const { t } = useTranslation(['common']);
 
-  useEffect(() => {
-    if (pathname.startsWith('/send')) {
-      setActive(0);
-    } else if (pathname.startsWith('/my-statistics')) {
-      setActive(1);
-    } else if (pathname === '/statistics') {
-      setActive(2);
-    } else {
-      setActive(0);
-    }
-  }, [pathname]);
+  const active = getActiveItem(pathname);
 
   return (
     <div className="w-full shrink flex justify-end">

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,5 +1,3 @@
-import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
 import { GetServerSideProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import DefaultLayout from '@layouts/default-layout/default-layout.component';
@@ -11,15 +9,11 @@ import { Link } from '@sk-web-gui/react';
 import HeaderMenu from '@components/header-menu/header-menu.component';
 
 const Index = () => {
-  const [isCheckingPermissions, setIsCheckingPermissions] = useState(true);
   const user = useUserStore((state) => state.user);
   const { canSendLetter, canSendRegisteredLetter, canSendSMS } = user?.permissions ?? {};
-  const router = useRouter();
   const { t } = useTranslation(['common', 'start-page']);
 
-  useEffect(() => {
-    setIsCheckingPermissions(false);
-  }, [canSendSMS, canSendLetter, canSendRegisteredLetter, router]);
+  const isCheckingPermissions = !user?.name;
 
   return (
     <DefaultLayout title={t('start-page:appTitle')} headerMenu={<HeaderMenu />}>

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -17,7 +17,7 @@ export function Start() {
   const initalFocus = useRef<HTMLButtonElement>(null);
   const setInitalFocus = () => {
     setTimeout(() => {
-      initalFocus.current && initalFocus.current.focus();
+      initalFocus.current?.focus();
     });
   };
 

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import EmptyLayout from '../layouts/empty-layout/empty-layout.component';
 import { useRouter } from 'next/router';
 import { Button, FormErrorMessage } from '@sk-web-gui/react';
@@ -12,8 +12,6 @@ import LoaderFullScreen from '@components/loader/loader-fullscreen';
 
 export function Start() {
   const router = useRouter();
-  const [message, setMessage] = useState<string>();
-  const [mounting, setMounting] = useState<boolean>(true);
   const { t } = useTranslation();
   const searchParams = useSearchParams();
   const initalFocus = useRef<HTMLButtonElement>(null);
@@ -22,6 +20,12 @@ export function Start() {
       initalFocus.current && initalFocus.current.focus();
     });
   };
+
+  const failMessage = router.query?.failMessage;
+  const message = failMessage ? t(`login:errors.${failMessage}`) : undefined;
+  // Any failure other than NOT_AUTHORIZED means the form is shown instead of
+  // bouncing the user straight back to SSO.
+  const showLogin = !!failMessage && failMessage !== 'NOT_AUTHORIZED';
 
   const onLogin = () => {
     // NOTE: send user to login with SSO
@@ -41,20 +45,17 @@ export function Start() {
 
   useEffect(() => {
     setInitalFocus();
-    if (router.query?.failMessage) {
-      setMessage(t(`login:errors.${router.query.failMessage}`));
-    }
   }, [router]);
 
   useEffect(() => {
-    if (router.query?.failMessage && router.query.failMessage !== 'NOT_AUTHORIZED') {
-      setMounting(false);
+    if (showLogin) {
       return;
     }
     onLogin();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return mounting ? (
+  return !showLogin ? (
     <LoaderFullScreen />
   ) : (
     <>

--- a/frontend/src/pages/logout.tsx
+++ b/frontend/src/pages/logout.tsx
@@ -11,7 +11,6 @@ export default function Logout() {
     });
     url.search = queries.toString();
     globalThis.location.href = url.toString();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return <></>;

--- a/frontend/src/services/api-service.ts
+++ b/frontend/src/services/api-service.ts
@@ -11,7 +11,6 @@ export interface ApiResponse<T> {
   message: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 let isRedirectingToLogin = false;
 
 Router.events.on('routeChangeComplete', (route) => {

--- a/frontend/src/services/my-statistics-service.ts
+++ b/frontend/src/services/my-statistics-service.ts
@@ -97,25 +97,37 @@ export const useMyLetterList = (): {
   return { letters, lettersLoaded };
 };
 
+const emptyUserMessage = createEmptyUserMessage();
+
 export const useMessage = (messageId: string): { message: UserMessage; loaded: boolean } => {
-  const [message, setMessage] = useState<UserMessage>(createEmptyUserMessage());
-  const [loaded, setLoaded] = useState<boolean>(false);
+  // Stored together with the id it was fetched for, so message and loaded can be
+  // derived rather than reset through the effect.
+  const [resolved, setResolved] = useState<{ messageId: string; message: UserMessage } | null>(null);
 
   useEffect(() => {
     if (!messageId) {
-      setLoaded(true);
       return;
     }
-    apiService.get<UserMessage>(`my-statistics/${messageId}`).then((res) => {
-      if (!res.data) return;
 
-      const message = res.data;
-      setMessage(message);
-      setLoaded(true);
+    let cancelled = false;
+
+    apiService.get<UserMessage>(`my-statistics/${messageId}`).then((res) => {
+      if (cancelled || !res.data) return;
+
+      setResolved({ messageId, message: res.data });
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, [messageId]);
 
-  return { message, loaded };
+  const isCurrent = resolved?.messageId === messageId;
+
+  return {
+    message: isCurrent ? resolved.message : emptyUserMessage,
+    loaded: !messageId || isCurrent,
+  };
 };
 
 export const useGetSigningInfo = (letterId: string) => {

--- a/frontend/src/services/recipient-service.ts
+++ b/frontend/src/services/recipient-service.ts
@@ -93,28 +93,28 @@ export const getCitizenName = async (personId: string): Promise<string> => {
 };
 
 export const useRecipientName = (recipient?: StatisticsRecipient) => {
-  const [name, setName] = useState('');
+  const partyId = recipient?.partyId;
+  const [resolved, setResolved] = useState<{ partyId: string; name: string } | null>(null);
 
   useEffect(() => {
-    if (!recipient?.partyId) {
-      setName('');
+    if (!partyId) {
       return;
     }
 
     let cancelled = false;
 
-    getCitizenName(recipient.partyId).then((name) => {
+    getCitizenName(partyId).then((name) => {
       if (!cancelled && name) {
-        setName(name);
+        setResolved({ partyId, name });
       }
     });
 
     return () => {
       cancelled = true;
     };
-  }, [recipient?.partyId]);
+  }, [partyId]);
 
-  return name;
+  return partyId && resolved?.partyId === partyId ? resolved.name : '';
 };
 
 const checkCsvByPath = async (csvFile: File, path: string): Promise<Csv> => {


### PR DESCRIPTION
# Pull Request

## Description

Fixes the 27 eslint errors that became visible once lint started working again.

Lint has been non-functional in both apps since `eslint-config-next` moved to 16,
the package is flat-config-only and crashed against the old `.eslintrc.json`
("Converting circular structure to JSON"), so it exited before inspecting a single
file. The flat config migration in HYDRAN-2516 makes lint run again, which is what
surfaced these errors. They are pre-existing, not introduced by that PR.

| | Before | After |
|---|---|---|
| admin | 19 errors | **0** |
| frontend | 8 errors | **0** |
| admin warnings | 5 | 3 |
| frontend warnings | 12 | 5 |

Also adds a `Lint` workflow. No workflow ran lint before, which is why this could
go unnoticed.

### Two real bugs that the `any`s and effects were hiding

1. **`edit-resource-view`** called `Object.keys(res)` on a failed request.
   `handleGetOne` returns `undefined` on error, so this threw and left the edit
   view stuck on its loader.
2. **`useMessage`** kept `loaded === true` while switching records, rendering the
   previous message's data as if it were current.

### Other notes

- Seven `react-refresh` errors were false positives: the rule only allowed
  `getServerSideProps` (Pages Router) while admin uses the App Router. Fixed in
  `admin/eslint.config.mjs`.
- Several `set-state-in-effect` errors were derived state mirrored into state via
  an effect. Deriving the value instead removes an extra render pass, among other
  things, the main menu no longer highlights the previous tab for one frame after
  navigating.
- Two `eslint-disable` comments referenced rules that do not exist ("no any",
  "implicit-any") and therefore suppressed nothing.

## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-2681

## Verification

Both Cypress suites are green on this branch, and both run `yarn build` as part of
the job. `tsc --noEmit` is clean in both apps.

The following changes passed CI without being asserted, no existing spec covers
them, and coverage should be added separately:

- active tab in the main menu
- `login.tsx` (there is no login spec at all)
- `useRecipientName`
- logotype preview in admin

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)

