### PR TITLE
Fix/hydran 2516 next config

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -27,6 +27,9 @@ module.exports = withBundleAnalyzer({
   basePath: process.env.NEXT_PUBLIC_BASEPATH ?? process.env.NEXT_PUBLIC_BASE_PATH ?? process.env.BASE_PATH ?? '',
   experimental: {},
   output: 'standalone',
+  outputFileTracingIncludes: {
+    '/**/*': ['./next-i18next.config.js'],
+  },
   i18n,
   async rewrites() {
     return [{ source: '/napi/:path*', destination: '/api/:path*' }];


### PR DESCRIPTION
# Pull Request

## Background & Motivation

Felmeddelande i OpenShift-poddarna efter uppdatering till Next 16: 
⨯ Error: next-i18next was unable to find a user config at /app/next-i18next.config.js at new Promise (<anonymous>)

Fix: Inkludera `next-i18next-config.js` i standalone output.

https://nextjs.org/docs/pages/api-reference/config/next-config-js/output

## General Checklist

- [X] PR follows code style and standards
- [X] E2E tests (Cypress) have been executed, and new tests have been added if required
- [X] Project builds locally without errors
- [X] ESLint/Prettier have been run and are OK
- [X] API changes are documented (OpenAPI/README)
- [X] Environment variables updated if necessary

## Manual Regression Testing

### Frontend – Next.js

- [X] All affected pages render correctly (SSR/CSR)
- [X] Navigation works
- [X] API calls from the frontend continue to work
- [X] Any forms/flows function correctly
- [X] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [X] Affected endpoints behave as expected
- [X] No changes break existing contracts
- [X] Error handling works correctly
- [X] Logging behaves normally
- [X] Protected endpoints validated (auth/session/JWT)